### PR TITLE
Switch RenIK to set_bone_global_pose_override

### DIFF
--- a/renik.h
+++ b/renik.h
@@ -44,8 +44,10 @@ public:
 	void update_ik();
 	void update_placement(float delta);
 
-	void apply_ik_map(Map<BoneId, Quat> ikMap);
-	void apply_ik_map(Map<BoneId, Basis> ikMap);
+	void apply_ik_map(Map<BoneId, Quat> ik_map, Transform global_parent, Vector<BoneId> apply_order);
+	void apply_ik_map(Map<BoneId, Basis> ik_map, Transform global_parent, Vector<BoneId> apply_order);
+	Vector<BoneId> bone_id_order(Ref<RenIKChain> chain);
+	Vector<BoneId> bone_id_order(Ref<RenIKLimb> limb);
 
 	Transform get_global_parent_pose(BoneId child, Map<BoneId, Quat> ik_map, Transform map_global_parent);
 

--- a/renik.h
+++ b/renik.h
@@ -432,6 +432,7 @@ private:
 	bool leftFootTrackerEnabled = true;
 	bool rightFootTrackerEnabled = true;
 
+	void calculate_hip_offset();
 	Vector<BoneId> calculate_bone_chain(BoneId root, BoneId leaf);
 };
 


### PR DESCRIPTION
Switches away from set_custom_bone_pose to set_bone_global_pose_override.
This is meant to be used with the new Skeleton API by marstaik (PR #41322)
The 3.2 backport by TokageItLab is available in V-Sekai/improve_skeleton_for_vrm_3.2